### PR TITLE
Flush responses from zone1

### DIFF
--- a/zone1/mzmsg.c
+++ b/zone1/mzmsg.c
@@ -93,6 +93,7 @@ int mzmsg_read(mzmsg_t *mzmsg, char *buf, size_t len){
             mzmsg->last_index = mzmsg->in[IND];
             mzmsg->out[ACK] = mzmsg->in[IND];
             mzmsg->out[CTL] |= CTL_ACK;
+            mzmsg->out[CTL] |= CTL_PSH;
 
             mzmsg_flush(mzmsg);
         } else {


### PR DESCRIPTION
This ensures flushing even when zone scheduling is reordered.