### PR TITLE
Protobuf proof of concept

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "ext/wolfssl"]
 	path = ext/wolfssl
 	url = https://github.com/wolfSSL/wolfssl.git
+[submodule "ext/nanopb"]
+	path = ext/nanopb
+	url = https://github.com/nanopb/nanopb

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Software requirements: Install the reference RISC-V toolchain for Linux - direct
  git submodule update --init --recursive
  sudo apt-get install libusb-0.1-4
  sudo apt-get install screen
+ sudo apt-get install protobuf-compiler and python-protobuf
 ```
 
 If you have not already done so, you need to edit or create a file to place the USB devices until plugdev group so you can access them without root privileges:

--- a/rpcmsg.proto
+++ b/rpcmsg.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+import "nanopb.proto";
+
+message EccSignRequest {
+    required bytes data = 1 [(nanopb).max_size = 256];
+}
+
+message EccSignResponse {
+    required int32 result = 1;
+    required bytes data = 2 [(nanopb).max_size = 256];
+}

--- a/rpcmsg.proto
+++ b/rpcmsg.proto
@@ -2,6 +2,10 @@ syntax = "proto2";
 
 import "nanopb.proto";
 
+service Zone3 {
+    rpc EccSign (EccSignRequest) returns (EccSignResponse) {}
+}
+
 message EccSignRequest {
     required bytes data = 1 [(nanopb).max_size = 256];
 }

--- a/zone2/Makefile
+++ b/zone2/Makefile
@@ -10,6 +10,10 @@ LINKER_SCRIPT := flash.lds
 
 C_SRCS += main.c
 
+C_SRCS += rpcmsg.pb.c ../ext/nanopb/pb_common.c ../ext/nanopb/pb_encode.c ../ext/nanopb/pb_decode.c
+HEADERS += rpcmsg.pb.h ../ext/nanopb/pb.h ../ext/nanopb/pb_common.h ../ext/nanopb/pb_encode.h ../ext/nanopb/pb_decode.h
+INCLUDES += -I../ext/nanopb
+
 WOLFSSL_SRC_DIR := ../ext/wolfssl
 # WOLFSSL TLS FILES
 C_SRCS += $(WOLFSSL_SRC_DIR)/src/crl.c
@@ -156,3 +160,11 @@ picotcp:
 		CYASSL=0 \
 		WOLFSSL=0 \
 		POLARSSL=0
+
+main.o: rpcmsg.pb.h
+
+rpcmsg.pb.c rpcmsg.pb.h: ../rpcmsg.proto
+	protoc -I/usr/include -I../ext/nanopb/generator/proto -I. -I.. -o rpcmsg.pb ../rpcmsg.proto
+	python ../ext/nanopb/generator/nanopb_generator.py rpcmsg.pb
+
+CLEAN_OBJS += rpcmsg.pb rpcmsg.pb.c rpcmsg.pb.h

--- a/zone3/Makefile
+++ b/zone3/Makefile
@@ -10,6 +10,10 @@ LINKER_SCRIPT := flash.lds
 
 C_SRCS += main.c 
 
+C_SRCS += rpcmsg.pb.c ../ext/nanopb/pb_common.c ../ext/nanopb/pb_encode.c ../ext/nanopb/pb_decode.c
+HEADERS += rpcmsg.pb.h ../ext/nanopb/pb.h ../ext/nanopb/pb_common.h ../ext/nanopb/pb_encode.h ../ext/nanopb/pb_decode.h
+INCLUDES += -I../ext/nanopb
+
 WOLFSSL_SRC_DIR := ../ext/wolfssl
 
 # Defines
@@ -69,3 +73,13 @@ LDFLAGS += -L../ext/multizone
 LDFLAGS += $(if $(findstring rv64, $(RISCV_ARCH)), -lhexfive64, -lhexfive32)
 
 include $(NEWLIB_DIR)/newlib.mk
+
+CFLAGS += -Os
+
+main.o: rpcmsg.pb.h
+
+rpcmsg.pb.c rpcmsg.pb.h: ../rpcmsg.proto
+	protoc -I/usr/include -I../ext/nanopb/generator/proto -I. -I.. -o rpcmsg.pb ../rpcmsg.proto
+	python ../ext/nanopb/generator/nanopb_generator.py rpcmsg.pb
+
+CLEAN_OBJS += rpcmsg.pb rpcmsg.pb.c rpcmsg.pb.h


### PR DESCRIPTION
Use protobuf/nanopb to serialize/deserialize messages between zone2 and zone3. Messages are defined in rpcmsg.proto and this is given to nanopb to produce the structs for serialization/deserialization. Function/API selector is still done manually, but I plan to add GRPC support after optimizing any overheads.

Future-wise, this should allow interesting concepts like doing RPC from a PC to the embedded board.